### PR TITLE
Let's Encrypt HTTPS certificate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ DB_USER=postgres
 DB_PASS=postgres
 WEB_PORT=443
 WEB_PORT_HTTP=80
-DOMAIN_NAME=localhost
+DOMAIN_NAME=local.dodobox.site
+# ACME_APIKEY=  # your api key for api.dodobox.site

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,3 +1,10 @@
+{
+	acme_dns acmerelay {
+		api_key {$ACME_APIKEY}
+		endpoint https://api.dodobox.site/acmerelay
+	}
+}
+
 {$DOMAIN_NAME}:{$WEB_PORT} {
 	reverse_proxy web:3000
 	encode zstd gzip

--- a/caddy/Dockerfile
+++ b/caddy/Dockerfile
@@ -1,5 +1,10 @@
-FROM caddy:2.2.1-alpine
+FROM caddy:builder-alpine as builder
 
+RUN xcaddy build --with github.com/dodobox-s-team/acmerelay-provider
+
+FROM caddy:2-alpine
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY ./Caddyfile /etc/caddy/Caddyfile
 
 WORKDIR /etc/caddy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
     depends_on:
       - api
   caddy:
-    build: ./caddy
+    image: mwath/dodobox-caddy:v1
     command: caddy run
     volumes:
       - caddy_data:/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,7 @@ services:
     environment:
       - WEB_PORT=${WEB_PORT}
       - DOMAIN_NAME=${DOMAIN_NAME}
+      - ACME_APIKEY=${ACME_APIKEY}
     ports:
       - "${WEB_PORT}:${WEB_PORT}"
       - "${WEB_PORT_HTTP}:80"


### PR DESCRIPTION
Mise en place d'un relai de validation ACME permettant d'obtenir un certificat Let's Encrypt (ou ZeroSSL) grâce à Caddy.

### Fonctionnement
Caddy est build avec le module [acmerelay-provider](https://github.com/dodobox-s-team/acmerelay-provider), ce qui permet d'utiliser la validation ACME par record DNS.
Le module communique à l'API externe Dodobox qui exécute elle-même les requêtes vers l'API d'OVH pour ajouter/supprimer des records TXT (contenant le challenge ACME).

```
Caddy   -------> Let's Encrypt   | Requête de certificat pour local.dodobox.site
Caddy   <------- Let's Encrypt   | Envoie le challenge
Caddy   -------> Dodobox Ext API | Relaie le challenge
API OVH <------- Dodobox Ext API | Ajoute le(s) record(s) TXT avec le challenge
API OVH -------> Dodobox Ext API | Succès / erreur
Caddy   <------- Dodobox Ext API | Succès / erreur
Caddy   -------> Let's Encrypt   | Informe du succès du l'ajout du challenge
Caddy   <------- Let's Encrypt   | Envoie le certificat en cas de succès
```