### PR TITLE
Amélioration des tests

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,9 +1,11 @@
 alembic~=1.7.4
+asgi-lifespan~=1.0.1
 asyncpg~=0.24.0
 cryptography~=35.0.0
 databases~=0.5.3
 fastapi~=0.70.0
 flake8
+httpx~=0.21.1
 passlib[bcrypt]~=1.7.4
 psycopg2~=2.9.1
 pytest~=6.2.5

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,6 +9,7 @@ psycopg2~=2.9.1
 pytest~=6.2.5
 pytest-asyncio~=0.16.0
 pytest-cov~=3.0.0
+pytest-mock
 python-jose~=3.3.0
 python-multipart~=0.0.5
 requests~=2.26.0

--- a/api/tests/models/conftest.py
+++ b/api/tests/models/conftest.py
@@ -1,15 +1,13 @@
+from typing import Any
+
 import pytest
-from api.schemas import db as database
+from pytest_mock import MockerFixture
 
 
 @pytest.fixture
-async def db():
-    await database.connect()
-    yield database
-    await database.disconnect()
+def apatch(mocker: MockerFixture):
+    """Return a function that let you patch an async function."""
+    def patch(target: str, return_value: Any):
+        return mocker.patch(target, side_effect=mocker.AsyncMock(return_value=return_value))
 
-
-@pytest.mark.asyncio
-async def test_db_connection():
-    await database.connect()
-    await database.disconnect()
+    yield patch

--- a/api/tests/models/test_devices.py
+++ b/api/tests/models/test_devices.py
@@ -1,13 +1,14 @@
 import pytest
 from api.models.devices import Device
 
+pytestmark = pytest.mark.asyncio
+
 device = Device(id=1, groupId=None, name="prise salon", modele="esp32", type=0, ip="192.168.1.9")
 modified_device = Device(id=1, groupId=None, name="prise pas du salon", modele="esp32", type=0, ip="192.168.1.9")
 device2 = Device(id=2, groupId=None, name="prise salon", modele="esp32", type=0, ip="192.168.1.9")
 
 
 class TestDevice:
-    @pytest.mark.asyncio
     async def test_add(self, apatch):
         apatch('api.schemas.db.execute', return_value=1)
         assert device == await Device.add(device)
@@ -15,7 +16,6 @@ class TestDevice:
         apatch('api.schemas.db.execute', return_value=2)
         assert device2 == await Device.add(device2)
 
-    @pytest.mark.asyncio
     async def test_get(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=device.dict())
         assert device == await Device.get(device.id)
@@ -26,12 +26,10 @@ class TestDevice:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Device.get(0) is None
 
-    @pytest.mark.asyncio
     async def test_get_all(self, apatch):
         apatch('api.schemas.db.fetch_all', return_value=[device.dict()])
         assert [device] == await Device.get_all()
 
-    @pytest.mark.asyncio
     async def test_update(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=modified_device.dict())
         assert modified_device == await Device.update(device.id, name=modified_device.name)
@@ -39,7 +37,6 @@ class TestDevice:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Device.update(0, name=modified_device.name) is None
 
-    @pytest.mark.asyncio
     async def test_edit(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=modified_device.dict())
         assert modified_device == await Device.edit(device.id, modified_device)
@@ -47,7 +44,6 @@ class TestDevice:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Device.edit(0, modified_device) is None
 
-    @pytest.mark.asyncio
     async def test_delete(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=device)
         assert device == await Device.delete(device.id)

--- a/api/tests/models/test_devices.py
+++ b/api/tests/models/test_devices.py
@@ -1,35 +1,56 @@
 import pytest
 from api.models.devices import Device
 
+device = Device(id=1, groupId=None, name="prise salon", modele="esp32", type=0, ip="192.168.1.9")
+modified_device = Device(id=1, groupId=None, name="prise pas du salon", modele="esp32", type=0, ip="192.168.1.9")
+device2 = Device(id=2, groupId=None, name="prise salon", modele="esp32", type=0, ip="192.168.1.9")
+
 
 class TestDevice:
-    device = Device(id=1, groupId=None, name="prise salon", modele="esp32", type=0, ip="192.168.1.9")
-    modified_device = Device(id=1, groupId=None, name="prise pas du salon", modele="esp32", type=0, ip="192.168.1.9")
-    device2 = Device(id=2, groupId=None, name="prise salon", modele="esp32", type=0, ip="192.168.1.9")
+    @pytest.mark.asyncio
+    async def test_add(self, apatch):
+        apatch('api.schemas.db.execute', return_value=1)
+        assert device == await Device.add(device)
+
+        apatch('api.schemas.db.execute', return_value=2)
+        assert device2 == await Device.add(device2)
 
     @pytest.mark.asyncio
-    async def test_add(self, db):
-        assert self.device == await Device.add(self.device)
+    async def test_get(self, apatch):
+        apatch('api.schemas.db.fetch_one', return_value=device.dict())
+        assert device == await Device.get(device.id)
+
+        apatch('api.schemas.db.fetch_one', return_value=device2.dict())
+        assert device2 == await Device.get(device2.id)
+
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Device.get(0) is None
 
     @pytest.mark.asyncio
-    async def test_get(self, db):
-        assert self.device == await Device.get(self.device.id)
-        assert await Device.get(8) is None
+    async def test_get_all(self, apatch):
+        apatch('api.schemas.db.fetch_all', return_value=[device.dict()])
+        assert [device] == await Device.get_all()
 
     @pytest.mark.asyncio
-    async def test_update(self, db):
-        assert self.modified_device == await Device.edit(self.device.id, self.modified_device)
-        assert self.modified_device == await Device.get(self.modified_device.id)
-        assert self.device != await Device.get(self.device.id)
+    async def test_update(self, apatch):
+        apatch('api.schemas.db.fetch_one', return_value=modified_device.dict())
+        assert modified_device == await Device.update(device.id, name=modified_device.name)
+
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Device.update(0, name=modified_device.name) is None
 
     @pytest.mark.asyncio
-    async def test_delete(self, db):
-        # Delete the device
-        assert self.modified_device == await Device.delete(self.modified_device.id)
-        # Check that the device were correctly deleted
-        assert await Device.get(self.modified_device.id) is None
+    async def test_edit(self, apatch):
+        apatch('api.schemas.db.fetch_one', return_value=modified_device.dict())
+        assert modified_device == await Device.edit(device.id, modified_device)
+
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Device.edit(0, modified_device) is None
 
     @pytest.mark.asyncio
-    async def test_get_all(self, db):
-        await Device.add(self.device2)
-        assert len(await Device.get_all()) == 1
+    async def test_delete(self, apatch):
+        apatch('api.schemas.db.fetch_one', return_value=device)
+        assert device == await Device.delete(device.id)
+
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Device.delete(0) is None

--- a/api/tests/models/test_groups.py
+++ b/api/tests/models/test_groups.py
@@ -4,6 +4,8 @@ from api.models.groups import Group
 from asyncpg import UniqueViolationError
 from pytest_mock import MockerFixture
 
+pytestmark = pytest.mark.asyncio
+
 group = Group(id=1, name="salon")
 modified_group = Group(id=1, name="Salon")
 group2 = Group(id=2, name="Cuisine")
@@ -11,7 +13,6 @@ device = Device(name="Lampe", modele="", groupId=1, type=1, ip="192.168.1.5")
 
 
 class TestGroup:
-    @pytest.mark.asyncio
     async def test_add(self, apatch, mocker: MockerFixture):
         apatch('api.schemas.db.execute', return_value=1)
         assert group == await Group.add(group)
@@ -24,7 +25,6 @@ class TestGroup:
         with pytest.raises(UniqueViolationError):
             await Group.add(group)
 
-    @pytest.mark.asyncio
     async def test_get(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=group.dict())
         assert group == await Group.get(group.id)
@@ -35,12 +35,10 @@ class TestGroup:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Group.get(0) is None
 
-    @pytest.mark.asyncio
     async def test_get_all(self, apatch):
         apatch('api.schemas.db.fetch_all', return_value=[group.dict()])
         assert [group] == await Group.get_all()
 
-    @pytest.mark.asyncio
     async def test_update(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=modified_group.dict())
         assert modified_group == await Group.update(group.id, name=modified_group.name)
@@ -48,7 +46,6 @@ class TestGroup:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Group.update(0, name=modified_group.name) is None
 
-    @pytest.mark.asyncio
     async def test_edit(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=modified_group.dict())
         assert modified_group == await Group.edit(group.id, modified_group)
@@ -56,7 +53,6 @@ class TestGroup:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Group.edit(0, modified_group) is None
 
-    @pytest.mark.asyncio
     async def test_delete(self, apatch, mocker):
         mocker.patch('api.schemas.db.execute')
         apatch('api.schemas.db.fetch_one', return_value=group.dict())
@@ -65,12 +61,10 @@ class TestGroup:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Group.delete(0) is None
 
-    @pytest.mark.asyncio
     async def test_get_devices(self, apatch):
         apatch('api.schemas.db.fetch_all', return_value=[device.dict()])
         assert [device] == await Group.get_devices(group.id)
 
-    @pytest.mark.asyncio
     async def test_delete_with_devices(self, apatch, mocker):
         def reset_groupId(query):
             device.groupId = None

--- a/api/tests/models/test_groups.py
+++ b/api/tests/models/test_groups.py
@@ -2,59 +2,83 @@ import pytest
 from api.models.devices import Device
 from api.models.groups import Group
 from asyncpg import UniqueViolationError
+from pytest_mock import MockerFixture
+
+group = Group(id=1, name="salon")
+modified_group = Group(id=1, name="Salon")
+group2 = Group(id=2, name="Cuisine")
+device = Device(name="Lampe", modele="", groupId=1, type=1, ip="192.168.1.5")
 
 
 class TestGroup:
-    group = Group(id=1, name="salon")
-    modified_group = Group(id=1, name="Salon")
-    group2 = Group(id=2, name="Cuisine")
-    device = Device(name="Lampe", modele="", type=1, ip="192.168.1.5")
-
     @pytest.mark.asyncio
-    async def test_add(self, db):
-        assert self.group == await Group.add(self.group)
+    async def test_add(self, apatch, mocker: MockerFixture):
+        apatch('api.schemas.db.execute', return_value=1)
+        assert group == await Group.add(group)
+
+        apatch('api.schemas.db.execute', return_value=2)
+        assert group2 == await Group.add(group2)
 
         # Check that two groups cannot have the same name
+        mocker.patch('api.schemas.db.execute', side_effect=UniqueViolationError())
         with pytest.raises(UniqueViolationError):
-            await Group.add(self.group)
+            await Group.add(group)
 
     @pytest.mark.asyncio
-    async def test_get(self, db):
-        assert self.group == await Group.get(self.group.id)
-        assert await Group.get(8) is None
+    async def test_get(self, apatch):
+        apatch('api.schemas.db.fetch_one', return_value=group.dict())
+        assert group == await Group.get(group.id)
+
+        apatch('api.schemas.db.fetch_one', return_value=group2.dict())
+        assert group2 == await Group.get(group2.id)
+
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Group.get(0) is None
 
     @pytest.mark.asyncio
-    async def test_update(self, db):
-        assert self.modified_group == await Group.edit(self.group.id, self.modified_group)
-        assert self.modified_group == await Group.get(self.modified_group.id)
-        assert self.group != await Group.get(self.group.id)
+    async def test_get_all(self, apatch):
+        apatch('api.schemas.db.fetch_all', return_value=[group.dict()])
+        assert [group] == await Group.get_all()
 
     @pytest.mark.asyncio
-    async def test_delete(self, db):
-        # Delete the group
-        assert self.modified_group == await Group.delete(self.modified_group.id)
-        # Check that the group were correctly deleted
-        assert await Group.get(self.modified_group.id) is None
+    async def test_update(self, apatch):
+        apatch('api.schemas.db.fetch_one', return_value=modified_group.dict())
+        assert modified_group == await Group.update(group.id, name=modified_group.name)
+
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Group.update(0, name=modified_group.name) is None
 
     @pytest.mark.asyncio
-    async def test_get_all(self, db):
-        self.group2 = await Group.add(self.group2)
-        print(self.group2)
-        assert len(await Group.get_all()) == 1
+    async def test_edit(self, apatch):
+        apatch('api.schemas.db.fetch_one', return_value=modified_group.dict())
+        assert modified_group == await Group.edit(group.id, modified_group)
+
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Group.edit(0, modified_group) is None
 
     @pytest.mark.asyncio
-    async def test_get_devices(self, db):
-        self.device = await Device.add(self.device)
-        self.device = await Device.update(self.device.id, groupId=self.group2.id)
+    async def test_delete(self, apatch, mocker):
+        mocker.patch('api.schemas.db.execute')
+        apatch('api.schemas.db.fetch_one', return_value=group.dict())
+        assert group == await Group.delete(group.id)
 
-        devices = await Group.get_devices(self.group2.id)
-        assert len(devices) == 1 and devices[0] == self.device
+        apatch('api.schemas.db.fetch_one', return_value=None)
+        assert await Group.delete(0) is None
 
     @pytest.mark.asyncio
-    async def test_delete_with_devices(self, db):
-        # Delete the group
-        assert self.group2 == await Group.delete(self.group2.id)
-        # Check that the group were correctly deleted
-        assert await Group.get(self.group2.id) is None
+    async def test_get_devices(self, apatch):
+        apatch('api.schemas.db.fetch_all', return_value=[device.dict()])
+        assert [device] == await Group.get_devices(group.id)
+
+    @pytest.mark.asyncio
+    async def test_delete_with_devices(self, apatch, mocker):
+        def reset_groupId(query):
+            device.groupId = None
+
+        mocker.patch('api.schemas.db.execute', side_effect=reset_groupId)
+        apatch('api.schemas.db.fetch_one', return_value=group.dict())
+        assert group == await Group.delete(group.id)
+
+        apatch('api.schemas.db.fetch_one', return_value=device.dict())
         # Check that the device doesn't have a group anymore
-        assert (await Device.get(self.device.id)).groupId is None
+        assert (await Device.get(device.id)).groupId is None

--- a/api/tests/models/test_timetables.py
+++ b/api/tests/models/test_timetables.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 import pytest
 from api.models.timetables import Timetable
 
+pytestmark = pytest.mark.asyncio
+
 timetable = Timetable(
     id=1, action="off", start=datetime.now(), duration=timedelta(minutes=5), repeat=timedelta(weeks=1)
 )
@@ -15,7 +17,6 @@ timetable2 = Timetable(
 
 
 class TestTimetable:
-    @pytest.mark.asyncio
     async def test_add(self, apatch):
         apatch('api.schemas.db.execute', return_value=1)
         assert timetable == await Timetable.add(timetable)
@@ -23,7 +24,6 @@ class TestTimetable:
         apatch('api.schemas.db.execute', return_value=2)
         assert timetable2 == await Timetable.add(timetable2)
 
-    @pytest.mark.asyncio
     async def test_get(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=timetable.dict())
         assert timetable == await Timetable.get(timetable.id)
@@ -34,12 +34,10 @@ class TestTimetable:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Timetable.get(69) is None
 
-    @pytest.mark.asyncio
     async def test_get_all(self, apatch):
         apatch('api.schemas.db.fetch_all', return_value=[timetable.dict()])
         assert [timetable] == await Timetable.get_all()
 
-    @pytest.mark.asyncio
     async def test_edit(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=modified_timetable.dict())
         assert modified_timetable == await Timetable.edit(timetable.id, modified_timetable)
@@ -47,7 +45,6 @@ class TestTimetable:
         apatch('api.schemas.db.fetch_one', return_value=None)
         assert await Timetable.edit(0, modified_timetable) is None
 
-    @pytest.mark.asyncio
     async def test_delete(self, apatch):
         apatch('api.schemas.db.fetch_one', return_value=modified_timetable.dict())
         assert modified_timetable == await Timetable.delete(modified_timetable.id)

--- a/api/tests/routers/conftest.py
+++ b/api/tests/routers/conftest.py
@@ -1,9 +1,99 @@
+import asyncio
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import api.models
 import pytest
 from api.main import app
-from fastapi.testclient import TestClient
+from api.models.devices import Device
+from api.models.groups import Group
+from api.models.timetables import Timetable
+from api.schemas import db
+from asgi_lifespan import LifespanManager
+from httpx import AsyncClient
+
+
+@pytest.fixture
+def device(setup_database):
+    return Device(id=11, groupId=None, name="prise salon", modele="esp32", type=0, ip="192.168.1.9")
+
+
+@pytest.fixture
+def group(setup_database):
+    return Group(id=11, name="salon")
+
+
+@pytest.fixture
+def device_group(setup_database):
+    return Device(id=12, groupId=11, name="Lampe", modele="", type=1, ip="192.168.1.5")
+
+
+@pytest.fixture
+def timetable(setup_database):
+    return Timetable(
+        id=11,
+        action="off",
+        start=datetime(1999, 1, 8, 4, 5, 6),
+        duration=timedelta(minutes=5),
+        repeat=timedelta(weeks=1)
+    )
+
+
+class patchdb:
+    """Patch the db object with a connection."""
+    def __init__(self, conn):
+        self.conn = conn
+        self._db = db
+        self.modules = [getattr(api.models, m) for m in dir(api.models) if not m.startswith('_')]
+
+    def _replace(self, db, value):
+        """Replace all db object by another value."""
+        api.schemas.db = value
+        for mod in self.modules:
+            if hasattr(mod, 'db') and mod.db is db:
+                mod.db = value
+
+    def __enter__(self):
+        self._replace(self._db, self.conn)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._replace(self.conn, self._db)
 
 
 @pytest.fixture(scope="session")
-def client():
-    with TestClient(app) as c:
-        yield c
+def event_loop():
+    # This fixture is needed because pytest-asyncio's event loop has a function scope but the
+    # `client` fixture has a session scope which is not compatible with the function scope.
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+async def client():
+    # httpx does not support ASGI lifecycles (e.g. startup & shutdown events)
+    # See https://github.com/encode/httpx/issues/350
+    async with LifespanManager(app):
+        async with AsyncClient(app=app, base_url="http://test") as c:
+            yield c
+
+
+@pytest.fixture(scope="session")
+async def setup_database(client):
+    # Populate the database with values
+    with open(Path(__file__).parent / 'setup.sql', 'r') as f:
+        for query in f.read().split(';'):
+            await db.execute(query)
+
+
+@pytest.fixture(autouse=True)
+async def dbtransaction(client):
+    # Wrap every test by a SQL transaction and roll back any changes to the db by the tests
+    # to prevent any side effect. We achieve it by replacing every instances of the database
+    # object by a single connection objectto prevent issues where the transaction is rolled
+    # back after the connection has been closed.
+    async with db.connection() as connection:
+        with patchdb(connection):
+            async with connection.transaction(force_rollback=True):
+                yield

--- a/api/tests/routers/setup.sql
+++ b/api/tests/routers/setup.sql
@@ -1,0 +1,11 @@
+-- Note: you should not use id 1 to prevent primary key unique violation
+
+-- devices --
+INSERT INTO devices VALUES (11, null, 'prise salon', 'esp32', 0, '192.168.1.9');
+
+-- groups --
+INSERT INTO groups VALUES (11, 'salon');
+INSERT INTO devices VALUES (12, 11, 'Lampe', '', 1, '192.168.1.5');
+
+-- timetables --
+INSERT INTO timetables VALUES (11, 'off', timestamp '1999-01-08 04:05:06', interval '5 minutes', interval '1 week');

--- a/api/tests/routers/test_route_groups.py
+++ b/api/tests/routers/test_route_groups.py
@@ -1,92 +1,99 @@
+import pytest
 from api.models.devices import Device
 from api.models.groups import Group
 from fastapi import status
 from fastapi.testclient import TestClient
 
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def group2(group):
+    return Group(id=1, name="Cuisine")
+
 
 class TestRouteGroup:
-    group = Group(name="salon")
-    device = Device(name="Lampe", modele="", type=1, ip="192.168.1.5")
-
-    def test_add_group(self, client: TestClient):
-        group = self.group.dict()
+    async def test_add_group(self, client: TestClient, group2: Group):
         # Add a group
-        response = client.post("/groups", json=group)
+        response = await client.post("/groups", json=group2.dict())
         assert response.status_code == status.HTTP_200_OK
-        assert isinstance(response.json().get("id"), int)  # The id must be given and should be an integer
-        self.group.id = response.json().get("id")  # Assign it so we can use it later and use Pydantic validation
-        assert response.json() == self.group
+        assert response.json() == group2
 
+        # Check if the group we added has been added.
+        # We run the tests against a fresh database every time, so it should contain only our group.
+        response = await client.get(f"/groups/{group2.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == group2
+
+    async def test_add_unique_group(self, client: TestClient, group: Group):
         # Make that two groups cannot have the same name
-        response = client.post("/groups", json=group)
+        response = await client.post("/groups", json=group.dict())
         assert response.status_code == status.HTTP_409_CONFLICT
 
-    def test_get_groups(self, client: TestClient):
-        # Check if the group we added in the previous test has been added.
-        # We run the tests against a fresh database every time, so it should contain only our group.
-        response = client.get("/groups")
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == [self.group]
-
-    def test_get_group(self, client: TestClient):
+    async def test_get_group(self, client: TestClient, group: Group):
         # Also check that the path to the individual resource works
-        response = client.get(f"/groups/{self.group.id}")
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == self.group
-
-        # Get a nonexistant resource should return 404
-        response = client.get("/groups/404")
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_edit_group(self, client: TestClient):
-        group = self.group.dict()
-        group["name"] = "Salon"
-
-        # Update a group that doesn't exist. It should return a 404 error.
-        response = client.put("/groups/666", json=group)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-        # Update the group's name.
-        response = client.put(f"/groups/{self.group.id}", json=group)
+        response = await client.get(f"/groups/{group.id}")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == group
 
-        # Update the new name for the following tests.
-        self.group.name = response.json()["name"]
+        # Get a nonexistant resource should return 404
+        response = await client.get("/groups/404")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_get_devices(self, client: TestClient):
-        # Add a device in the group
-        self.device.groupId = self.group.id
-        response = client.post("/devices", json=self.device.dict())
+    async def test_edit_group(self, client: TestClient, group: Group):
+        group.name = new_name = "Salon"
+
+        # Update a group that doesn't exist. It should return a 404 error.
+        response = await client.put("/groups/666", json=group.dict())
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+        # Update the group's name.
+        response = await client.put(f"/groups/{group.id}", json=group.dict())
         assert response.status_code == status.HTTP_200_OK
-        # Update the device for later validations
-        self.device.id = response.json()["id"]
+        assert response.json() == group
 
+        # Check the name has changed
+        response = await client.get(f"/groups/{group.id}")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json().get("name") == new_name
+
+    async def test_get_devices(self, client: TestClient, group: Group, device_group: Device):
         # Check that the device is in the group
-        response = client.get(f"/groups/{self.group.id}/devices")
+        response = await client.get(f"/groups/{group.id}/devices")
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == [self.device]
+        assert response.json() == [device_group]
 
-    def test_delete_group(self, client: TestClient):
+    async def test_add_device(self, client: TestClient, group: Group, device: Device, device_group: Device):
+        device.groupId = group.id
+        # Add a device in the group
+        response = await client.put(f"/devices/{device.id}", json=device.dict())
+        assert response.status_code == status.HTTP_200_OK
+
+        # Check that the device has been added in the group
+        response = await client.get(f"/groups/{group.id}/devices")
+        assert response.status_code == status.HTTP_200_OK
+        assert device in response.json()
+
+    async def test_delete_group(self, client: TestClient, group: Group, device_group: Device):
         # Check for a group that doesn't exists
-        response = client.delete("/groups/666")
+        response = await client.delete("/groups/666")
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
         # Delete the group.
-        response = client.delete(f"/groups/{self.group.id}")
+        response = await client.delete(f"/groups/{group.id}")
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == self.group
+        assert response.json() == group
 
         # Check that the group does not exists anymore.
-        response = client.get("/groups")
+        response = await client.get("/groups")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
 
         # Check if the device was removed from the group
-        response = client.get(f"/devices/{self.device.id}")
+        response = await client.get(f"/devices/{device_group.id}")
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["groupId"] is None
 
         # Remove the device
-        response = client.delete(f"/devices/{self.device.id}")
+        response = await client.delete(f"/devices/{device_group.id}")
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Les tests dans le dossier `models` utilise maintenant des Mock et n'interagissent plus avec la base de donnée.
Les tests dans le dossier `routers` sont désormais indépendant les uns des autres. Ils utilisent une transaction qui est annulée à la fin du test pour ne pas perturber les autres tests.